### PR TITLE
fix(android): remove stale warmup class entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Android**: removed two stale warmup class names so automatic foreground-service warmup no longer emits harmless `Warmup class not found` debug lines for `NotificationManager` and `ChannelModel`.
+
 ## [10.4.4] - 2026-05-29
 
 ### Fixed

--- a/packages/react-native/android/src/main/java/app/notifee/core/WarmupHelper.java
+++ b/packages/react-native/android/src/main/java/app/notifee/core/WarmupHelper.java
@@ -39,10 +39,8 @@ public final class WarmupHelper {
 
   static final String[] WARMUP_CLASSES = {
     "app.notifee.core.ForegroundService",
-    "app.notifee.core.NotificationManager",
     "app.notifee.core.model.NotificationModel",
     "app.notifee.core.model.NotificationAndroidModel",
-    "app.notifee.core.model.ChannelModel",
     "androidx.core.app.NotificationCompat$Builder",
     "androidx.core.app.NotificationManagerCompat",
   };


### PR DESCRIPTION
## Summary

This pull request removes two stale warmup class names from
`WarmupHelper.WARMUP_CLASSES` so automatic warmup no longer emits harmless
`Warmup class not found` debug lines for `NotificationManager` and
`ChannelModel`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Build / CI / tooling
- [ ] Other

## Related issue

Closes https://github.com/marcocrupi/react-native-notify-kit/issues/40



## Scope

- [x] This pull request is focused on one logical change.
- [x] I have not included unrelated cleanup or formatting changes.
- [x] I have not changed public APIs, runtime behavior, native configuration, package metadata, or documentation scope unless explicitly intended.

## Validation

Describe the validation performed.

- [ ] `yarn format:all`
- [ ] `yarn validate:all`
- [ ] `yarn test:all`
- [x] Manual Android validation
- [ ] Manual iOS validation
- [ ] Not applicable

Manual validation details:

```text
Platform: Android
Device / simulator: emulator / downstream app
OS version: Android 16 / SDK 36
React Native version: 0.85.3
Scenario tested: app startup with automatic warmup enabled; verified that the
two stale class names no longer produce avoidable debug log noise.
```

## Documentation

- [ ] Documentation was updated.
- [x] `CHANGELOG.md` was updated under `[Unreleased]`.
- [x] Documentation changes are not needed.
- [ ] Changelog entry is not needed because this is not a user-facing product change.

## Breaking changes

Does this pull request introduce a breaking change?

- [x] No
- [ ] Yes
