### PR TITLE
fix(android): recover stale headless react context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Android**: reinitialized the headless React host when `HeadlessTask` still thought React was initialized but `getCurrentReactContext()` had already become `null`, so queued background tasks could still reach JS.
+
 ## [10.4.4] - 2026-05-29
 
 ### Fixed

--- a/packages/react-native/android/src/main/kotlin/io/invertase/notifee/HeadlessTask.kt
+++ b/packages/react-native/android/src/main/kotlin/io/invertase/notifee/HeadlessTask.kt
@@ -96,10 +96,22 @@ class HeadlessTask {
             mTaskQueue.add(taskConfig)
         }
 
-        if (!mIsReactContextInitialized.get()) {
+        val reactContext = getReactContext(context)
+        if (!mIsReactContextInitialized.get() || reactContext == null) {
+            if (mIsReactContextInitialized.get() && reactContext == null) {
+                Log.w(
+                    HEADLESS_TASK_NAME,
+                    "ReactContext was marked initialized but is no longer available; " +
+                        "reinitializing before starting task ${taskConfig.taskId}",
+                )
+                mIsReactContextInitialized.set(false)
+                mIsInitializingReactContext.set(false)
+                mWillDrainTaskQueue.set(false)
+                mIsHeadlessJsTaskListenerRegistered.set(false)
+            }
             createReactContextAndScheduleTask(context)
         } else {
-            invokeStartTask(getReactContext(context)!!, taskConfig)
+            invokeStartTask(reactContext, taskConfig)
         }
     }
 
@@ -143,6 +155,7 @@ class HeadlessTask {
         val reactContext = getReactContext(context)
         if (reactContext != null && !mIsInitializingReactContext.get()) {
             mIsReactContextInitialized.set(true)
+            mWillDrainTaskQueue.set(false)
             drainTaskQueue(reactContext)
             return
         }
@@ -152,6 +165,8 @@ class HeadlessTask {
             val callback = object : ReactInstanceEventListener {
                 override fun onReactContextInitialized(reactCtx: ReactContext) {
                     mIsReactContextInitialized.set(true)
+                    mIsInitializingReactContext.set(false)
+                    mWillDrainTaskQueue.set(false)
                     drainTaskQueue(reactCtx)
                     try {
                         val removeMethod = reactHost!!.javaClass.getMethod(
@@ -186,6 +201,7 @@ class HeadlessTask {
                         for (taskConfig in mTaskQueue) {
                             invokeStartTask(reactContext, taskConfig)
                         }
+                        mWillDrainTaskQueue.set(false)
                     }
                 },
                 500,

--- a/packages/react-native/android/src/test/java/io/invertase/notifee/HeadlessTaskReactHostTest.java
+++ b/packages/react-native/android/src/test/java/io/invertase/notifee/HeadlessTaskReactHostTest.java
@@ -101,6 +101,63 @@ public class HeadlessTaskReactHostTest {
         copiedParams.getInt("taskId"));
   }
 
+  @Test
+  public void startTask_whenInitializedContextDisappears_reinitializesReactHost() {
+    JavaOnlyMap firstParams = new JavaOnlyMap();
+    firstParams.putString("source", "first-task");
+    JavaOnlyMap secondParams = new JavaOnlyMap();
+    secondParams.putString("source", "second-task");
+
+    HeadlessTask headlessTask = new HeadlessTask();
+    HeadlessTask.TaskConfig firstTask =
+        new HeadlessTask.TaskConfig("test-headless-task", 60000L, firstParams, null);
+    HeadlessTask.TaskConfig secondTask =
+        new HeadlessTask.TaskConfig("test-headless-task", 60000L, secondParams, null);
+    ReactContext firstReactContext = mock(ReactContext.class);
+    ReactContext secondReactContext = mock(ReactContext.class);
+    AppRegistry firstAppRegistry = mock(AppRegistry.class);
+    AppRegistry secondAppRegistry = mock(AppRegistry.class);
+
+    when(firstReactContext.getLifecycleState()).thenReturn(LifecycleState.BEFORE_RESUME);
+    when(firstReactContext.hasActiveReactInstance()).thenReturn(true);
+    when(firstReactContext.getJSModule(AppRegistry.class)).thenReturn(firstAppRegistry);
+    when(secondReactContext.getLifecycleState()).thenReturn(LifecycleState.BEFORE_RESUME);
+    when(secondReactContext.hasActiveReactInstance()).thenReturn(true);
+    when(secondReactContext.getJSModule(AppRegistry.class)).thenReturn(secondAppRegistry);
+
+    headlessTask.startTask(application, firstTask);
+    application.reactHost.currentReactContext = firstReactContext;
+    application.reactHost.listeners.get(0).onReactContextInitialized(firstReactContext);
+    Shadows.shadowOf(Looper.getMainLooper())
+        .idleFor(500, java.util.concurrent.TimeUnit.MILLISECONDS);
+    verify(firstAppRegistry)
+        .startHeadlessTask(
+            anyInt(), eq("test-headless-task"), same(firstTask.getTaskConfig().getData()));
+
+    application.reactHost.currentReactContext = null;
+    headlessTask.startTask(application, secondTask);
+
+    assertEquals(
+        "ReactHost should be started again after the cached ReactContext disappears",
+        2,
+        application.reactHost.startCalls);
+    assertEquals(
+        "A fresh ReactContext listener should be registered for the second headless task",
+        1,
+        application.reactHost.listeners.size());
+    verify(secondAppRegistry, never())
+        .startHeadlessTask(anyInt(), any(String.class), any(WritableMap.class));
+
+    application.reactHost.currentReactContext = secondReactContext;
+    application.reactHost.listeners.get(0).onReactContextInitialized(secondReactContext);
+    Shadows.shadowOf(Looper.getMainLooper())
+        .idleFor(500, java.util.concurrent.TimeUnit.MILLISECONDS);
+
+    verify(secondAppRegistry)
+        .startHeadlessTask(
+            anyInt(), eq("test-headless-task"), same(secondTask.getTaskConfig().getData()));
+  }
+
   public static class TestApplication extends Application {
     final TestReactHost reactHost = new TestReactHost();
 
@@ -111,10 +168,11 @@ public class HeadlessTaskReactHostTest {
 
   public static class TestReactHost {
     int startCalls;
+    ReactContext currentReactContext;
     final List<ReactInstanceEventListener> listeners = new ArrayList<>();
 
     public ReactContext getCurrentReactContext() {
-      return null;
+      return currentReactContext;
     }
 
     public void addReactInstanceEventListener(ReactInstanceEventListener listener) {
@@ -131,6 +189,7 @@ public class HeadlessTaskReactHostTest {
 
     void reset() {
       startCalls = 0;
+      currentReactContext = null;
       listeners.clear();
     }
   }


### PR DESCRIPTION
## Summary

This pull request makes `HeadlessTask` recover when it still thinks React is
initialized but `getCurrentReactContext()` has already become `null`.

Instead of trying to launch the JS task immediately and failing before delivery,
it resets the stale state, recreates the React host, and drains the queued
task. A Robolectric regression test is included.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Test
- [ ] Build / CI / tooling
- [ ] Other

## Related issue

Closes https://github.com/marcocrupi/react-native-notify-kit/issues/39

## Scope

- [x] This pull request is focused on one logical change.
- [x] I have not included unrelated cleanup or formatting changes.
- [x] I have not changed public APIs, runtime behavior, native configuration, package metadata, or documentation scope unless explicitly intended.

## Validation

Describe the validation performed.

- [ ] `yarn format:all`
- [ ] `yarn validate:all`
- [ ] `yarn test:all`
- [x] Manual Android validation
- [ ] Manual iOS validation
- [ ] Not applicable

Manual validation details:

```text
Platform: Android
Device / simulator: downstream app validation + Robolectric regression test scenario
OS version: Android 16 / SDK 36
React Native version: 0.85.3
Scenario tested: first headless event initializes React, later event arrives after
getCurrentReactContext() has become null; verified that the host is started again
and the queued task can be delivered instead of failing before JS.
```

## Documentation

- [ ] Documentation was updated.
- [x] `CHANGELOG.md` was updated under `[Unreleased]`.
- [x] Documentation changes are not needed.
- [ ] Changelog entry is not needed because this is not a user-facing product change.

## Breaking changes

Does this pull request introduce a breaking change?

- [x] No
- [ ] Yes