### PR TITLE
fix(android): keep no-launch actions on receiverservice path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Android**: kept Android 12+ notification actions without `launchActivity` or `mainComponent` on the `ReceiverService` path instead of always routing them through the launch-activity `PendingIntent`.
+
 ## [10.4.4] - 2026-05-29
 
 ### Fixed

--- a/packages/react-native/android/src/main/java/app/notifee/core/NotificationManager.java
+++ b/packages/react-native/android/src/main/java/app/notifee/core/NotificationManager.java
@@ -451,23 +451,27 @@ class NotificationManager {
                     PendingIntent pendingIntent = null;
                     int targetSdkVersion =
                         ContextHolder.getApplicationContext().getApplicationInfo().targetSdkVersion;
+                    NotificationAndroidPressActionModel pressAction = actionBundle.getPressAction();
+                    boolean shouldCreateLaunchActivityIntent =
+                        NotificationPendingIntent.shouldCreateLaunchActivityIntent(pressAction);
                     if (targetSdkVersion >= Build.VERSION_CODES.S
-                        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                        && shouldCreateLaunchActivityIntent) {
                       pendingIntent =
                           NotificationPendingIntent.createIntent(
                               notificationModel.getHashCode(),
-                              actionBundle.getPressAction().toBundle(),
+                              pressAction.toBundle(),
                               TYPE_ACTION_PRESS,
                               new String[] {"notification", "pressAction"},
                               notificationModel.toBundle(),
-                              actionBundle.getPressAction().toBundle());
+                              pressAction.toBundle());
                     } else {
                       pendingIntent =
                           ReceiverService.createIntent(
                               ACTION_PRESS_INTENT,
                               new String[] {"notification", "pressAction"},
                               notificationModel.toBundle(),
-                              actionBundle.getPressAction().toBundle());
+                              pressAction.toBundle());
                     }
 
                     String icon = actionBundle.getIcon();


### PR DESCRIPTION
## Summary

This pull request keeps Android 12+ notification actions without
`launchActivity` or `mainComponent` on the headless `ReceiverService` path
instead of always routing them through the launch-activity `PendingIntent`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] Build / CI / tooling
- [ ] Other

## Related issue

Closes https://github.com/marcocrupi/react-native-notify-kit/issues/38

## Scope

- [x] This pull request is focused on one logical change.
- [x] I have not included unrelated cleanup or formatting changes.
- [x] I have not changed public APIs, runtime behavior, native configuration, package metadata, or documentation scope unless explicitly intended.

## Validation

Describe the validation performed.

- [ ] `yarn format:all`
- [ ] `yarn validate:all`
- [ ] `yarn test:all`
- [x] Manual Android validation
- [ ] Manual iOS validation
- [ ] Not applicable

Manual validation details:

```text
Platform: Android
Device / simulator: Android emulator + downstream app validation
OS version: Android 16 / SDK 36
React Native version: 0.85.3
Scenario tested: incoming-call notification with one action that launches the app
and one action (`Decline`) with no launch metadata; verified that the no-launch
action stays on the headless service path while launch actions keep opening the app.
```

## Documentation

- [ ] Documentation was updated.
- [x] `CHANGELOG.md` was updated under `[Unreleased]`.
- [x] Documentation changes are not needed.
- [ ] Changelog entry is not needed because this is not a user-facing product change.

## Breaking changes

Does this pull request introduce a breaking change?

- [x] No
- [ ] Yes