### PR TITLE
fix: resolve NotifeeApiModule lazily to fix New Arch (bridgeless) import-time crash

### DIFF
--- a/packages/react-native/src/NotifeeNativeModule.ts
+++ b/packages/react-native/src/NotifeeNativeModule.ts
@@ -13,20 +13,20 @@ export interface NativeModuleConfig {
 }
 
 export default class NotifeeNativeModule {
-  private _nativeModule: Spec;
-  private _nativeEmitter: NativeEventEmitter;
+  private readonly _config: NativeModuleConfig;
+  private _nativeModule?: Spec;
+  private _nativeEmitter?: NativeEventEmitter;
 
   public constructor(config: NativeModuleConfig) {
-    this._nativeModule = TurboModuleRegistry.getEnforcing<Spec>(config.nativeModuleName);
-
-    // @ts-ignore - change here needs resolution https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49560/files
-    this._nativeEmitter = new NativeEventEmitter(this.native as EventSubscription['subscriber']);
-    for (let i = 0; i < config.nativeEvents.length; i++) {
-      const eventName = config.nativeEvents[i];
-      this._nativeEmitter.addListener(eventName, (payload: any) => {
-        this.emitter.emit(eventName, payload);
-      });
-    }
+    // Defer all native access out of the constructor. The default export of this package is a
+    // singleton constructed at module-evaluation time, so resolving the TurboModule here meant
+    // it ran the instant `react-native-notify-kit` was imported. On the New Architecture in
+    // bridgeless mode, importing the package early (e.g. registering `onBackgroundEvent` at the
+    // top of index.js, before the app root mounts) executes before TurboModules are installed,
+    // so `getEnforcing` throws "NotifeeApiModule could not be found" / "runtime not ready" and
+    // the module is unusable for the whole session. Resolving lazily on first `.native` access
+    // defers it until a notifee method actually runs, when the TurboModule is available.
+    this._config = config;
   }
 
   public get emitter() {
@@ -34,6 +34,18 @@ export default class NotifeeNativeModule {
   }
 
   public get native(): Spec {
+    if (!this._nativeModule) {
+      this._nativeModule = TurboModuleRegistry.getEnforcing<Spec>(this._config.nativeModuleName);
+
+      // @ts-ignore - change here needs resolution https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49560/files
+      this._nativeEmitter = new NativeEventEmitter(this._nativeModule as EventSubscription['subscriber']);
+      for (let i = 0; i < this._config.nativeEvents.length; i++) {
+        const eventName = this._config.nativeEvents[i];
+        this._nativeEmitter.addListener(eventName, (payload: any) => {
+          this.emitter.emit(eventName, payload);
+        });
+      }
+    }
     return this._nativeModule;
   }
 }


### PR DESCRIPTION
Fixes #42.

## Problem

`NotifeeNativeModule`'s constructor resolves the native TurboModule eagerly (`TurboModuleRegistry.getEnforcing(...)` + `new NativeEventEmitter(...)`). Because the package's default export is a **singleton built at module‑evaluation time**, importing `react-native-notify-kit` runs that constructor immediately.

On the **New Architecture in bridgeless mode**, an early import — e.g. registering `notifee.onBackgroundEvent(...)` at the top of `index.js`, before the app root mounts — executes before TurboModules are installed, so `getEnforcing` throws:

```
[runtime not ready]: Invariant Violation: TurboModuleRegistry.getEnforcing(...):
'NotifeeApiModule' could not be found.
```

and notifee is then unusable for the whole session (no channels created, nothing displays), even though the native module is correctly linked.

## Fix

Defer native access out of the constructor into the lazy `native` getter. The constructor now stores only the config; `getEnforcing` + the `NativeEventEmitter` (and its listeners) run on the **first `.native` access** — i.e. when a notifee method actually executes, by which point TurboModules are installed. No public API change; identical behavior once any native method is called.

## Notes

- Purely an import‑time timing issue on bridgeless — the native module itself was correctly linked (Android `NotifeePackage`, iOS `install_modules_dependencies`).
- Verified against `react-native@0.85.3` / New Arch (bridgeless) / Expo SDK 56: applying the equivalent change to the published `dist/` (via patch‑package) resolves the crash — channels are created and pushes display.
