### PR TITLE
fix(android): fall back to ReactNativeHost when the app exposes no bridgeless ReactHost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Android**: fixed React Native bridge events being dropped on the Old Architecture (bridge mode) when the application exposes no bridgeless `ReactHost` — `getReactHost()` returning `null` threw `java.lang.AssertionError: getReactHost() is null in New Architecture`, so `onForegroundEvent` never fired for presses (or dismiss/delivery) and headless task startup failed; the same assertion inside the queued-task drain callback could crash the main thread. For such applications, event delivery and headless task initialization now fall back to `ReactNativeHost`/`ReactInstanceManager`, as upstream Notifee's pre-migration dual-architecture path did. New Architecture (bridgeless) applications are unaffected. ([#47](https://github.com/marcocrupi/react-native-notify-kit/issues/47))
+
+### Tests
+
+- **Android**: added `HeadlessTask`/`NotifeeReactUtils` regression coverage for the Old Architecture fallback path (application without a `ReactHost`), covering `getReactContext()` resolution, foreground event emission, and headless task initialization via `ReactInstanceManager`.
+
 ## [10.4.8] - 2026-07-09
 
 ### Added

--- a/packages/react-native/android/src/main/kotlin/io/invertase/notifee/HeadlessTask.kt
+++ b/packages/react-native/android/src/main/kotlin/io/invertase/notifee/HeadlessTask.kt
@@ -38,8 +38,9 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import app.notifee.core.EventSubscriber
-import com.facebook.infer.annotation.Assertions
+import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceEventListener
+import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.WritableMap
@@ -163,31 +164,54 @@ class HeadlessTask {
         if (mIsInitializingReactContext.compareAndSet(false, true)) {
             Log.d(HEADLESS_TASK_NAME, "initialize ReactContext")
             val reactHost = getReactHost(context)
-            val callback = object : ReactInstanceEventListener {
-                override fun onReactContextInitialized(reactCtx: ReactContext) {
-                    mIsReactContextInitialized.set(true)
-                    drainTaskQueue(context, reactCtx)
-                    try {
-                        val removeMethod = reactHost!!.javaClass.getMethod(
-                            "removeReactInstanceEventListener",
-                            ReactInstanceEventListener::class.java,
-                        )
-                        removeMethod.invoke(reactHost, this)
-                    } catch (e: Exception) {
-                        Log.e(HEADLESS_TASK_NAME, "reflection error A: $e", e)
+            if (reactHost != null) { // New Architecture (bridgeless)
+                val callback = object : ReactInstanceEventListener {
+                    override fun onReactContextInitialized(reactCtx: ReactContext) {
+                        mIsReactContextInitialized.set(true)
+                        drainTaskQueue(context, reactCtx)
+                        try {
+                            val removeMethod = reactHost.javaClass.getMethod(
+                                "removeReactInstanceEventListener",
+                                ReactInstanceEventListener::class.java,
+                            )
+                            removeMethod.invoke(reactHost, this)
+                        } catch (e: Exception) {
+                            Log.e(HEADLESS_TASK_NAME, "reflection error A: $e", e)
+                        }
                     }
                 }
-            }
-            try {
-                val addMethod = reactHost!!.javaClass.getMethod(
-                    "addReactInstanceEventListener",
-                    ReactInstanceEventListener::class.java,
+                try {
+                    val addMethod = reactHost.javaClass.getMethod(
+                        "addReactInstanceEventListener",
+                        ReactInstanceEventListener::class.java,
+                    )
+                    addMethod.invoke(reactHost, callback)
+                    val startMethod = reactHost.javaClass.getMethod("start")
+                    startMethod.invoke(reactHost)
+                } catch (e: Exception) {
+                    Log.e(HEADLESS_TASK_NAME, "reflection error ReactHost start: ${e.message}", e)
+                }
+            } else { // Old Architecture (bridge)
+                val reactInstanceManager = getReactNativeHost(context)?.reactInstanceManager
+                if (reactInstanceManager == null) {
+                    Log.e(
+                        HEADLESS_TASK_NAME,
+                        "Failed to initialize ReactContext: the application provides " +
+                            "neither a ReactHost nor a ReactNativeHost",
+                    )
+                    mIsInitializingReactContext.set(false)
+                    return
+                }
+                reactInstanceManager.addReactInstanceEventListener(
+                    object : ReactInstanceEventListener {
+                        override fun onReactContextInitialized(reactCtx: ReactContext) {
+                            mIsReactContextInitialized.set(true)
+                            drainTaskQueue(context, reactCtx)
+                            reactInstanceManager.removeReactInstanceEventListener(this)
+                        }
+                    },
                 )
-                addMethod.invoke(reactHost, callback)
-                val startMethod = reactHost.javaClass.getMethod("start")
-                startMethod.invoke(reactHost)
-            } catch (e: Exception) {
-                Log.e(HEADLESS_TASK_NAME, "reflection error ReactHost start: ${e.message}", e)
+                reactInstanceManager.createReactContextInBackground()
             }
         }
     }
@@ -254,12 +278,37 @@ class HeadlessTask {
         }
 
         @JvmStatic
+        fun getReactNativeHost(context: Context): ReactNativeHost? {
+            val reactApplication = context.applicationContext as? ReactApplication
+            if (reactApplication == null) {
+                Log.w(
+                    HEADLESS_TASK_NAME,
+                    "Application context does not implement ReactApplication",
+                )
+                return null
+            }
+            return try {
+                reactApplication.reactNativeHost
+            } catch (e: Exception) {
+                // RN 0.83+'s default ReactApplication.reactNativeHost getter throws
+                // in bridgeless apps that do not override it.
+                Log.w(HEADLESS_TASK_NAME, "Failed to resolve ReactNativeHost: ${e.message}")
+                null
+            }
+        }
+
+        @JvmStatic
         @SuppressLint("VisibleForTests")
         fun getReactContext(context: Context): ReactContext? {
             val reactHost = getReactHost(context)
-            Assertions.assertNotNull(reactHost, "getReactHost() is null in New Architecture")
+            if (reactHost == null) {
+                // Old Architecture (bridge): the application exposes no bridgeless
+                // ReactHost, so resolve the context through the ReactNativeHost's
+                // ReactInstanceManager, like upstream Notifee does.
+                return getReactNativeHost(context)?.reactInstanceManager?.currentReactContext
+            }
             try {
-                val method = reactHost!!.javaClass.getMethod("getCurrentReactContext")
+                val method = reactHost.javaClass.getMethod("getCurrentReactContext")
                 return method.invoke(reactHost) as? ReactContext
             } catch (e: Exception) {
                 Log.e(

--- a/packages/react-native/android/src/test/java/io/invertase/notifee/HeadlessTaskOldArchTest.java
+++ b/packages/react-native/android/src/test/java/io/invertase/notifee/HeadlessTaskOldArchTest.java
@@ -1,0 +1,161 @@
+package io.invertase.notifee;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Application;
+import android.os.Looper;
+import androidx.annotation.Nullable;
+import app.notifee.core.ContextHolder;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactHost;
+import com.facebook.react.ReactInstanceEventListener;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.bridge.JavaOnlyMap;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.LifecycleState;
+import com.facebook.react.modules.appregistry.AppRegistry;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
+
+/**
+ * Regression coverage for the Old Architecture (bridge mode) fallback, where the application
+ * exposes no bridgeless ReactHost (getReactHost() returns null) and the React context must be
+ * resolved through ReactNativeHost/ReactInstanceManager.
+ *
+ * <p>Prior to the fix for marcocrupi/react-native-notify-kit#47, getReactContext() threw
+ * "AssertionError: getReactHost() is null in New Architecture" in this configuration, which
+ * silently dropped every bridge event (onForegroundEvent press/dismiss/delivery) and broke headless
+ * task startup on the Old Architecture.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(application = HeadlessTaskOldArchTest.TestApplication.class, sdk = 34)
+@LooperMode(LooperMode.Mode.PAUSED)
+public class HeadlessTaskOldArchTest {
+
+  private TestApplication application;
+  private ReactNativeHost reactNativeHost;
+  private ReactInstanceManager reactInstanceManager;
+
+  @Before
+  public void setUp() {
+    application = (TestApplication) RuntimeEnvironment.getApplication();
+    reactNativeHost = mock(ReactNativeHost.class);
+    reactInstanceManager = mock(ReactInstanceManager.class);
+    when(reactNativeHost.getReactInstanceManager()).thenReturn(reactInstanceManager);
+    application.reactNativeHost = reactNativeHost;
+    ContextHolder.setApplicationContext(application);
+    Shadows.shadowOf(Looper.getMainLooper()).idle();
+  }
+
+  @Test
+  public void getReactContext_withoutReactHost_fallsBackToReactInstanceManager() {
+    ReactContext reactContext = mock(ReactContext.class);
+    when(reactInstanceManager.getCurrentReactContext()).thenReturn(reactContext);
+
+    assertSame(reactContext, HeadlessTask.getReactContext(application));
+  }
+
+  @Test
+  public void sendEvent_withoutReactHost_emitsToDeviceEventEmitter() {
+    DeviceEventManagerModule.RCTDeviceEventEmitter emitter =
+        mock(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
+    ReactContext reactContext = mock(ReactContext.class);
+    when(reactContext.hasActiveReactInstance()).thenReturn(true);
+    when(reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class))
+        .thenReturn(emitter);
+    when(reactInstanceManager.getCurrentReactContext()).thenReturn(reactContext);
+
+    JavaOnlyMap eventMap = new JavaOnlyMap();
+    eventMap.putString("source", "old-arch-test");
+    NotifeeReactUtils.INSTANCE.sendEvent("app.notifee.notification-event", eventMap);
+
+    verify(emitter).emit("app.notifee.notification-event", eventMap);
+  }
+
+  @Test
+  public void startTask_withoutReactHost_initializesViaReactInstanceManagerAndDrains() {
+    JavaOnlyMap params = new JavaOnlyMap();
+    params.putString("source", "old-arch-test");
+
+    HeadlessTask headlessTask = new HeadlessTask();
+    HeadlessTask.TaskConfig taskConfig =
+        new HeadlessTask.TaskConfig("old-arch-headless-task", 60000L, params, null);
+    AppRegistry appRegistry = mock(AppRegistry.class);
+    ReactContext reactContext = createReactContext(appRegistry);
+
+    WritableMap copiedParams = taskConfig.getTaskConfig().getData();
+
+    headlessTask.startTask(application, taskConfig);
+
+    ArgumentCaptor<ReactInstanceEventListener> listenerCaptor =
+        ArgumentCaptor.forClass(ReactInstanceEventListener.class);
+    verify(reactInstanceManager).addReactInstanceEventListener(listenerCaptor.capture());
+    verify(reactInstanceManager).createReactContextInBackground();
+    verify(appRegistry, never())
+        .startHeadlessTask(anyInt(), any(String.class), any(WritableMap.class));
+
+    when(reactInstanceManager.getCurrentReactContext()).thenReturn(reactContext);
+    ReactInstanceEventListener listener = listenerCaptor.getValue();
+    listener.onReactContextInitialized(reactContext);
+
+    verify(reactInstanceManager).removeReactInstanceEventListener(listener);
+    Shadows.shadowOf(Looper.getMainLooper())
+        .idleFor(499, java.util.concurrent.TimeUnit.MILLISECONDS);
+    verify(appRegistry, never())
+        .startHeadlessTask(anyInt(), any(String.class), any(WritableMap.class));
+
+    Shadows.shadowOf(Looper.getMainLooper()).idleFor(1, java.util.concurrent.TimeUnit.MILLISECONDS);
+
+    ArgumentCaptor<Integer> taskIdCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(appRegistry)
+        .startHeadlessTask(
+            taskIdCaptor.capture(), eq("old-arch-headless-task"), same(copiedParams));
+    assertEquals(taskIdCaptor.getValue().intValue(), taskConfig.getReactTaskId());
+    assertEquals(
+        "copied params should receive the native task id",
+        taskConfig.getTaskId(),
+        copiedParams.getInt("taskId"));
+  }
+
+  private static ReactContext createReactContext(AppRegistry appRegistry) {
+    ReactContext reactContext = mock(ReactContext.class);
+    when(reactContext.getLifecycleState()).thenReturn(LifecycleState.BEFORE_RESUME);
+    when(reactContext.hasActiveReactInstance()).thenReturn(true);
+    when(reactContext.getJSModule(AppRegistry.class)).thenReturn(appRegistry);
+    return reactContext;
+  }
+
+  public static class TestApplication extends Application implements ReactApplication {
+    ReactNativeHost reactNativeHost;
+
+    @Override
+    public ReactNativeHost getReactNativeHost() {
+      return reactNativeHost;
+    }
+
+    // Old Architecture applications expose no bridgeless ReactHost.
+    @Override
+    public @Nullable ReactHost getReactHost() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #47.

## Problem

On the Old Architecture (bridge mode), tapping a notification received while the app is in the foreground never triggers `notifee.onForegroundEvent`. Logcat shows every event dying inside EventBus:

```
Could not dispatch event: class app.notifee.core.event.NotificationEvent to subscribing class class app.notifee.core.EventSubscriber
java.lang.AssertionError: getReactHost() is null in New Architecture
    at io.invertase.notifee.HeadlessTask$Companion.getReactContext(HeadlessTask.kt)
    at io.invertase.notifee.NotifeeReactUtils.sendEvent(NotifeeReactUtils.kt)
```

## Root cause

The Kotlin bridge migration (7f8f36d) replaced upstream Notifee's dual‑architecture `HeadlessTask.java` with a bridgeless‑only path:

- `getReactContext()` resolves the React context **exclusively** through a reflective `application.getReactHost()`. RN's `ReactApplication.reactHost` default getter returns `null` (verified against the shipped `react-android` AAR: `getReactHost()` is a JVM default method compiled to `aconst_null; areturn`), so on bridge‑mode apps whose `MainApplication` doesn't override it the reflective call returns null.
- `Assertions.assertNotNull` then throws `java.lang.AssertionError` — an `Error`, not an `Exception` — so it escapes `sendEvent`'s `catch (e: Exception)` and kills the EventBus dispatch. Every JS‑bound event is affected on the Old Architecture: foreground press/dismiss/delivery, and headless task startup (`reactHost!!` NPE, caught and logged, tasks never start).
- Worse: the same `getReactContext()` call inside `drainTaskQueue`'s `postDelayed` lambda runs with **no** try/catch — on the Old Architecture that `AssertionError` is an uncaught main‑thread exception (process crash), not just a dropped event.

Upstream Notifee never had this bug because `HeadlessTask.java` branches: bridgeless → `ReactHost` (reflection), otherwise → `ReactNativeHost.getReactInstanceManager()`. The reporter migrated from `@notifee/react-native`, where the identical app works.

## Fix

Restore the second branch, keyed on host absence: when `getReactHost()` returns `null`, resolve the context via `(application as ReactApplication).reactNativeHost.reactInstanceManager`, and initialize headless contexts via `addReactInstanceEventListener` + `createReactContextInBackground()` (internally guarded/idempotent since RN 0.57 — same unguarded call RN's own `HeadlessJsTaskService` makes). The New‑Architecture path is behaviorally unchanged for non‑null hosts (only the now‑unnecessary `!!`s dropped).

Design notes:

- **Keying on host‑null instead of upstream's `DefaultNewArchitectureEntryPoint.getBridgelessEnabled()`**: a null host is unambiguous (a bridgeless app cannot boot without one), it cannot regress any currently working New‑Arch app, and it keeps the existing Robolectric harness (`HeadlessTaskReactHostTest`, `NotifeeEventSubscriberRoutingTest` — both model a non‑null host) meaningful without global flag manipulation.
- **Known limitation (pre‑existing, different symptom, not introduced here)**: an Old‑Arch app built from the modern RN template unconditionally overrides `reactHost = getDefaultReactHost(...)`, returns a non‑null never‑started bridgeless host, and still takes the ReactHost path (events queue silently; no AssertionError — never produces #47's stack). That configuration was equally broken before this PR; happy to tackle it separately, since it needs upstream's flag‑keying plus test‑harness changes (much larger blast radius).
- `getReactNativeHost()` guards the property access because RN 0.83+'s default `reactNativeHost` getter throws in bridgeless apps that don't override it.
- The README states "New Architecture only"; this PR doesn't change that support claim. Old‑Arch apps already largely work through the TurboModule interop layer (per the reporter, everything but event delivery worked) — this restores the event path the way upstream Notifee handled it. Happy to adjust the README instead if you'd rather scope support explicitly.

## Tests

New `HeadlessTaskOldArchTest` (Robolectric, mirrors the existing harness) with a `TestApplication` whose `getReactHost()` returns null:

- `getReactContext_withoutReactHost_fallsBackToReactInstanceManager`
- `sendEvent_withoutReactHost_emitsToDeviceEventEmitter` — the exact #47 scenario
- `startTask_withoutReactHost_initializesViaReactInstanceManagerAndDrains`

All three **fail on pre‑fix code with exactly the reported error** (`java.lang.AssertionError: getReactHost() is null in New Architecture`) and pass with the fix. The full `:react-native-notify-kit:testDebugUnitTest` suite is green (including the 10.4.5 stale‑context recovery tests), and `yarn format:all` is clean.

## Verification note

Neither smoke app runs the legacy bridge, so verification is via the unit suite plus static parity against upstream Notifee's `HeadlessTask.java` (and `javap` on the shipped RN AARs for the reflective surface). @faizankh4 — a build from this branch on your RN 0.77 app would be a great real‑device confirmation.

One triage detail: the stack frames in the issue (`HeadlessTask.kt:243`, `NotifeeReactUtils.kt:109`) match v9.2–v9.5 line numbers rather than 10.4.8, so the installed binary there looks older than reported — but the offending code is identical from v9.2.0 through current `dev`, so the fix applies regardless.
