### PR TITLE
fix(server): mark react-native peer dependency as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Server SDK**: marked the `react-native` peer dependency as optional in `peerDependenciesMeta`, so package managers that auto-install peer dependencies (npm 7+, pnpm with `auto-install-peers`) no longer force a full React Native tree (~175 MB resolved closure) into pure-Node backends that only consume `react-native-notify-kit/server`. React Native applications are unaffected: the peer range (`>=0.73.0`) is still validated whenever `react-native` is present in the consumer's tree, and autolinking never reads a library's peer declarations. ([#46](https://github.com/marcocrupi/react-native-notify-kit/issues/46))
+
 ## [10.4.8] - 2026-07-09
 
 ### Added

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -68,6 +68,9 @@
   "peerDependenciesMeta": {
     "expo": {
       "optional": true
+    },
+    "react-native": {
+      "optional": true
     }
   },
   "codegenConfig": {


### PR DESCRIPTION
Partially addresses #46 — it removes the forced React Native install for server-only consumers with a one-line metadata change, without deciding the package-split question (that remains yours to evaluate; details below).

## Problem

A pure-Node backend that only consumes `react-native-notify-kit/server` gets a full React Native tree force-installed, because the package declares `react-native >=0.73.0` as a **hard** peer dependency and modern package managers auto-install non-optional peers. Reproduced against the published `10.4.8` tarball with a bare `package.json` (npm 10 / node 20):

| | packages installed | `node_modules` size | `react-native` present |
|---|---|---|---|
| before (hard peer) | 243 | **175 MB** | yes — `0.86.0`, `"peer": true` in lockfile |
| after (optional peer) | 19 | **6.8 MB** | no |

It's actually worse than the 33 MB reported in #46: npm resolves the whole RN peer closure (react, @react-native/*, etc.). And it's not npm-only — **pnpm's default `auto-install-peers=true` does the same** (173 MB → 6.8 MB with this fix), and bun too (232 → 19 packages). Yarn only warns, and the optional flag silences that warning.

## Fix

One line: add `react-native` to `peerDependenciesMeta` as optional — the same treatment `expo` already has (since 5a315f7f). No mainstream package manager auto-installs an optional peer that nothing else requires.

## Why this is safe for React Native app consumers (all verified empirically)

- **Version validation is NOT lost.** Optional peers are still range-checked when present: installing the patched tarball into a project with `react-native@0.72.0` still hard-fails with `ERESOLVE … peerOptional react-native@">=0.73.0" … Found: react-native@0.72.0`, and a compatible RN (0.74/0.81) installs cleanly. Apps keep the `>=0.73` TurboModules floor.
- **Autolinking cannot be affected.** RN CLI's `findDependencies` enumerates only the *app's own* manifest to decide what to link — a library's peer declarations are never consulted. Expo's `expo-modules-autolinking` traverses non-optional peers precisely "because some package managers auto-install them" and **explicitly skips optional ones** (`isOptionalPeerDependencyMeta`). The config plugin (`app.plugin.js`) resolves by package name. Native builds (podspec `install_modules_dependencies`, `com.facebook.react` gradle plugin) read no npm peer metadata.
- **The server entry is fully self-contained without RN.** In the RN-free backend fixture, `require('react-native-notify-kit/server')` works and `buildNotifyKitPayload(...)` produces a complete payload; the published `server/dist` has zero non-relative `require()` calls, and its `.d.ts` chain terminates at the shipped `fcmContract.d.ts` with zero imports — `tsc --strict` passes on an RN-free consumer.
- **Established pattern**: widely-used packages ship `react-native` as an optional peer for exactly this universal-consumer reason.

## What this PR deliberately does *not* do

It doesn't shrink the package itself: backends still download the client + native sources (registry: 2,681,876 bytes unpacked / 390 files — plus the CLI's small `optionalDependencies`). Removing that residue is what the package split proposed in #46 would buy, and that's a real product decision (second npm name, publish pipeline, deprecation window for the `./server` subpath) that this PR intentionally leaves open. This change is complementary either way — the split, if you do it, removes the last ~7 MB; this line removes the ~168 MB today.

## Verification

- `yarn verify:consumer-resolution` — all three `moduleResolution` modes PASS, blocked-subpath checks PASS (the script's header asks for this before releases touching `packages/react-native/package.json`).
- Full local runs of the CI jobs this diff triggers: `validate:all:js`, `validate:all:ts`, Jest (30 suites / 485 tests) — all green. The JUnit workflow correctly won't trigger (no `android/**` paths in the diff).
- `docs/react-native/installation.mdx` ("React Native: `>=0.73` (peer dependency)") stays literally true — no doc changes needed.
- Commit is typed `fix(server)` so semantic-release picks it up as a patch (`build:`/`chore:` would never publish under the current `.releaserc`).

One setup note unrelated to this change: `npm pack` (and therefore `verify:consumer-resolution`) fails on a fresh clone because `scripts/prepack-cli.sh` copies `packages/cli/bin/`, which is gitignored and only exists on machines that have published before. I restored the two-line shim from the registry tarball locally to run the checks. Might be worth committing that shim or generating it in `prepack-cli.sh` — happy to send a tiny follow-up PR if useful.
