### PR TITLE
fix(ios): export API methods to the legacy bridge for Old Architecture support

### DIFF
--- a/packages/react-native/ios/RNNotifee/NotifeeApiModule.mm
+++ b/packages/react-native/ios/RNNotifee/NotifeeApiModule.mm
@@ -97,6 +97,10 @@ RCT_EXPORT_MODULE();
   return @{@"ANDROID_API_LEVEL" : @0};
 }
 
+- (NSDictionary *)constantsToExport {
+  return [self getConstants];
+}
+
 #pragma mark - Events
 
 - (void)didReceiveNotifeeCoreEvent:(NSDictionary *_Nonnull)event {
@@ -149,93 +153,93 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Shared Methods
 
-- (void)cancelAllNotifications:(RCTPromiseResolveBlock)resolve
-                        reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelAllNotifications:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelAllNotifications:kReactNativeNotifeeNotificationTypeAll withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)cancelDisplayedNotifications:(RCTPromiseResolveBlock)resolve
-                              reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelDisplayedNotifications:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelAllNotifications:kReactNativeNotifeeNotificationTypeDisplayed withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)cancelTriggerNotifications:(RCTPromiseResolveBlock)resolve
-                            reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelTriggerNotifications:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelAllNotifications:kReactNativeNotifeeNotificationTypeTrigger withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)cancelAllNotificationsWithIds:(NSArray *)ids
-                     notificationType:(double)notificationType
-                                  tag:(NSString *_Nullable)tag
-                              resolve:(RCTPromiseResolveBlock)resolve
-                               reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelAllNotificationsWithIds:(NSArray *)ids
+                  notificationType:(double)notificationType
+                  tag:(NSString *_Nullable)tag
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   // tag is Android-only, ignored on iOS
   [NotifeeCore cancelAllNotificationsWithIds:(NSInteger)notificationType withIds:ids withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)getDisplayedNotifications:(RCTPromiseResolveBlock)resolve
-                           reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getDisplayedNotifications:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore getDisplayedNotifications:^(NSError *_Nullable error, NSArray<NSDictionary *> *notifications) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:notifications];
   }];
 }
 
-- (void)getTriggerNotifications:(RCTPromiseResolveBlock)resolve
-                         reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getTriggerNotifications:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore getTriggerNotifications:^(NSError *_Nullable error, NSArray<NSDictionary *> *notifications) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:notifications];
   }];
 }
 
-- (void)getTriggerNotificationIds:(RCTPromiseResolveBlock)resolve
-                           reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getTriggerNotificationIds:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore getTriggerNotificationIds:^(NSError *_Nullable error, NSArray<NSDictionary *> *notifications) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:notifications];
   }];
 }
 
-- (void)displayNotification:(NSDictionary *)notification
-                    resolve:(RCTPromiseResolveBlock)resolve
-                     reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(displayNotification:(NSDictionary *)notification
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore displayNotification:notification withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)createTriggerNotification:(NSDictionary *)notification
-                          trigger:(NSDictionary *)trigger
-                          resolve:(RCTPromiseResolveBlock)resolve
-                           reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(createTriggerNotification:(NSDictionary *)notification
+                  trigger:(NSDictionary *)trigger
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore createTriggerNotification:notification withTrigger:trigger withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)requestPermission:(NSDictionary *)permissions
+RCT_EXPORT_METHOD(requestPermission:(NSDictionary *)permissions
                   resolve:(RCTPromiseResolveBlock)resolve
-                   reject:(RCTPromiseRejectBlock)reject {
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore requestPermission:permissions withBlock:^(NSError *_Nullable error, NSDictionary *settings) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:settings];
   }];
 }
 
-- (void)getNotificationSettings:(RCTPromiseResolveBlock)resolve
-                         reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getNotificationSettings:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore getNotificationSettings:^(NSError *_Nullable error, NSDictionary *settings) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:settings];
   }];
 }
 
-- (void)getInitialNotification:(RCTPromiseResolveBlock)resolve
-                        reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getInitialNotification:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore getInitialNotification:^(NSError *_Nullable error, NSDictionary *notification) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:notification];
   }];
@@ -243,95 +247,95 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - iOS-only Methods
 
-- (void)cancelNotification:(NSString *)notificationId
-                   resolve:(RCTPromiseResolveBlock)resolve
-                    reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelNotification:(NSString *)notificationId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelNotification:notificationId withNotificationType:kReactNativeNotifeeNotificationTypeAll withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)cancelDisplayedNotification:(NSString *)notificationId
-                            resolve:(RCTPromiseResolveBlock)resolve
-                             reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelDisplayedNotification:(NSString *)notificationId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelNotification:notificationId withNotificationType:kReactNativeNotifeeNotificationTypeDisplayed withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)cancelTriggerNotification:(NSString *)notificationId
-                          resolve:(RCTPromiseResolveBlock)resolve
-                           reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelTriggerNotification:(NSString *)notificationId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelNotification:notificationId withNotificationType:kReactNativeNotifeeNotificationTypeTrigger withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)cancelDisplayedNotificationsWithIds:(NSArray *)ids
-                                    resolve:(RCTPromiseResolveBlock)resolve
-                                     reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelDisplayedNotificationsWithIds:(NSArray *)ids
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelAllNotificationsWithIds:kReactNativeNotifeeNotificationTypeDisplayed withIds:ids withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)cancelTriggerNotificationsWithIds:(NSArray *)ids
-                                  resolve:(RCTPromiseResolveBlock)resolve
-                                   reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(cancelTriggerNotificationsWithIds:(NSArray *)ids
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore cancelAllNotificationsWithIds:kReactNativeNotifeeNotificationTypeTrigger withIds:ids withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)getNotificationCategories:(RCTPromiseResolveBlock)resolve
-                           reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getNotificationCategories:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore getNotificationCategories:^(NSError *_Nullable error, NSArray<NSDictionary *> *categories) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:categories];
   }];
 }
 
-- (void)setNotificationCategories:(NSArray *)categories
-                          resolve:(RCTPromiseResolveBlock)resolve
-                           reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(setNotificationCategories:(NSArray *)categories
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore setNotificationCategories:categories withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)setBadgeCount:(double)count
-              resolve:(RCTPromiseResolveBlock)resolve
-               reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(setBadgeCount:(double)count
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore setBadgeCount:(NSInteger)count withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)getBadgeCount:(RCTPromiseResolveBlock)resolve
-               reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getBadgeCount:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore getBadgeCount:^(NSError *_Nullable error, NSInteger count) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:@(count)];
   }];
 }
 
-- (void)incrementBadgeCount:(double)incrementBy
-                    resolve:(RCTPromiseResolveBlock)resolve
-                     reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(incrementBadgeCount:(double)incrementBy
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore incrementBadgeCount:(NSInteger)incrementBy withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)decrementBadgeCount:(double)decrementBy
-                    resolve:(RCTPromiseResolveBlock)resolve
-                     reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(decrementBadgeCount:(double)decrementBy
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore decrementBadgeCount:(NSInteger)decrementBy withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
 }
 
-- (void)setNotificationConfig:(NSDictionary *)config
-                      resolve:(RCTPromiseResolveBlock)resolve
-                       reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(setNotificationConfig:(NSDictionary *)config
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   [NotifeeCore setNotificationConfig:config withBlock:^(NSError *_Nullable error) {
     [self resolve:resolve orReject:reject promiseWithError:error orResult:nil];
   }];
@@ -339,118 +343,118 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Android-only stubs (required by NativeNotifeeModuleSpec)
 
-- (void)createChannel:(NSDictionary *)channelMap
-              resolve:(RCTPromiseResolveBlock)resolve
-               reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(createChannel:(NSDictionary *)channelMap
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)createChannels:(NSArray *)channelsArray
-               resolve:(RCTPromiseResolveBlock)resolve
-                reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(createChannels:(NSArray *)channelsArray
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)createChannelGroup:(NSDictionary *)channelGroupMap
-                   resolve:(RCTPromiseResolveBlock)resolve
-                    reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(createChannelGroup:(NSDictionary *)channelGroupMap
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)createChannelGroups:(NSArray *)channelGroupsArray
-                    resolve:(RCTPromiseResolveBlock)resolve
-                     reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(createChannelGroups:(NSArray *)channelGroupsArray
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)deleteChannel:(NSString *)channelId
-              resolve:(RCTPromiseResolveBlock)resolve
-               reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(deleteChannel:(NSString *)channelId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)deleteChannelGroup:(NSString *)channelGroupId
-                   resolve:(RCTPromiseResolveBlock)resolve
-                    reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(deleteChannelGroup:(NSString *)channelGroupId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)getChannel:(NSString *)channelId
-           resolve:(RCTPromiseResolveBlock)resolve
-            reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getChannel:(NSString *)channelId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)getChannels:(RCTPromiseResolveBlock)resolve
-             reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getChannels:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)getChannelGroup:(NSString *)channelGroupId
-                resolve:(RCTPromiseResolveBlock)resolve
-                 reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getChannelGroup:(NSString *)channelGroupId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)getChannelGroups:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getChannelGroups:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)isChannelCreated:(NSString *)channelId
-                 resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(isChannelCreated:(NSString *)channelId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(@(NO));
 }
 
-- (void)isChannelBlocked:(NSString *)channelId
-                 resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(isChannelBlocked:(NSString *)channelId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(@(NO));
 }
 
-- (void)openAlarmPermissionSettings:(RCTPromiseResolveBlock)resolve
-                             reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(openAlarmPermissionSettings:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)openNotificationSettings:(NSString *_Nullable)channelId
-                         resolve:(RCTPromiseResolveBlock)resolve
-                          reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(openNotificationSettings:(NSString *_Nullable)channelId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)openBatteryOptimizationSettings:(RCTPromiseResolveBlock)resolve
-                                 reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(openBatteryOptimizationSettings:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)isBatteryOptimizationEnabled:(RCTPromiseResolveBlock)resolve
-                              reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(isBatteryOptimizationEnabled:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(@(NO));
 }
 
-- (void)getPowerManagerInfo:(RCTPromiseResolveBlock)resolve
-                     reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(getPowerManagerInfo:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(@{});
 }
 
-- (void)openPowerManagerSettings:(RCTPromiseResolveBlock)resolve
-                          reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(openPowerManagerSettings:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)stopForegroundService:(RCTPromiseResolveBlock)resolve
-                       reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(stopForegroundService:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)prewarmForegroundService:(RCTPromiseResolveBlock)resolve
-                          reject:(RCTPromiseRejectBlock)reject {
+RCT_EXPORT_METHOD(prewarmForegroundService:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
   resolve(nil);
 }
 
-- (void)hideNotificationDrawer {
+RCT_EXPORT_METHOD(hideNotificationDrawer) {
   // Android-only, no-op on iOS
 }
 


### PR DESCRIPTION
## Problem

On Old Architecture (bridge/Paper) apps, every iOS API call throws on first use:

```
TypeError: _this.native.displayNotification is not a function
```

Reported in the #47 thread (2026-07-16): after the Android old-arch fix from #48, Android works but iOS fails with exactly this TypeError. Tracked as #50.

## Root cause

`packages/react-native/ios/RNNotifee/NotifeeApiModule.mm` was New-Architecture-only. It has `RCT_EXPORT_MODULE()` and conforms to the codegen spec (`NativeNotifeeModuleSpec`, `getTurboModule:` returning `NativeNotifeeModuleSpecJSI`), but contained **zero** `RCT_EXPORT_METHOD` macros (upstream `@notifee/react-native` has them for every method).

On the New Architecture the methods are invoked through the generated spec, so nothing was missing. On the Old Architecture, `TurboModuleRegistry.getEnforcing('NotifeeApiModule')` falls back to `NativeModules`: `RCT_EXPORT_MODULE()` makes the module *resolve* (so `getEnforcing` doesn't throw), but the bridge only exports methods declared with `RCT_EXPORT_METHOD` — here, only `addListener`/`removeListeners` inherited from `RCTEventEmitter`. The JS layer then calls `this.native.displayNotification(...)` on a method-less module object → TypeError.

## Fix

- Convert every JS-callable method (shared, iOS-only, and the Android-only stubs required by the spec) from a plain method definition to `RCT_EXPORT_METHOD(...)` with an **identical selector and argument types**. The macro defines the same instance method, so `NativeNotifeeModuleSpec` conformance and the TurboModule path are byte-for-byte unchanged, while the legacy bridge now exports all 45 methods (including `hideNotificationDrawer`).
- `addListener:` / `removeListeners:` keep plain overrides — the `RCTEventEmitter` base class already `RCT_EXPORT_METHOD`s those selectors; re-exporting would duplicate bridge registration. The internal `resolve:orReject:promiseWithError:orResult:` helper is untouched.
- Add `constantsToExport` delegating to the existing `getConstants`, so `NativeModules.NotifeeApiModule.getConstants().ANDROID_API_LEVEL` also works on the legacy bridge (`requiresMainQueueSetup` already returns `YES`).
- No JS/TS changes; no version bump and no manual CHANGELOG edit (semantic-release generates the entry from the commit message).

This is the iOS twin of #48 (Android Old Architecture support).

## Verification matrix

| Check | Setup | Result |
|---|---|---|
| Build A — Old Architecture | RN 0.81.6 harness app, `RCT_NEW_ARCH_ENABLED=0 pod install` ("Configuring the target with the Legacy Architecture"), `xcodebuild` Debug, generic iOS Simulator destination, Xcode 26.6 | ✅ compiles, 0 errors (`NotifeeApiModule.mm` built for x86_64 + arm64) |
| Build B — New Architecture (regression) | `apps/smoke` (RN 0.85.3, New Arch), `pod install` + `xcodebuild` Debug, generic iOS Simulator destination | ✅ BUILD SUCCEEDED, 0 errors |
| JS unit tests | `yarn tests_rn:test` | ✅ 30 suites / 485 tests passed |
| Runtime smoke — Old Architecture | Legacy-arch harness on iPhone 16 Pro sim (iOS 18.3): `requestPermission` → `displayNotification` → `getBadgeCount` | ✅ all resolve, notification banner displayed, no TypeError |

Note on Build A's app: `apps/smoke` runs RN 0.85, which removed Old-Architecture support entirely (RN ≥0.82 hard-forces `RCT_NEW_ARCH_ENABLED=1` at pod install), so the old-arch build/runtime verification uses a dedicated RN 0.81.6 app consuming this package via autolinking — the same setup old-arch users actually run. Happy to contribute that harness as an old-arch regression app in a follow-up if useful.

Fixes #50
Refs #47
