### PR TITLE
fix(android): copy Fresco bitmap before it escapes the data subscriber

### DIFF
--- a/packages/react-native/android/src/main/java/app/notifee/core/utility/ResourceUtils.java
+++ b/packages/react-native/android/src/main/java/app/notifee/core/utility/ResourceUtils.java
@@ -170,7 +170,21 @@ public class ResourceUtils {
         new BaseBitmapDataSubscriber() {
           @Override
           protected void onNewResultImpl(@Nullable Bitmap bitmap) {
-            bitmapTCS.set(bitmap);
+            // Fresco owns this pooled bitmap and only guarantees it is valid for the
+            // duration of this callback. If it escapes without a copy, Fresco may
+            // recycle it on memory-cache eviction (e.g. onTrimMemory) while the
+            // notification is still being built, posted or re-parceled, crashing with
+            // "Can't copy/parcel a recycled bitmap" or "Canvas: trying to use a
+            // recycled bitmap".
+            if (bitmap == null) {
+              bitmapTCS.set(null);
+              return;
+            }
+            Bitmap.Config config = bitmap.getConfig();
+            if (config == null) {
+              config = Bitmap.Config.ARGB_8888;
+            }
+            bitmapTCS.set(bitmap.copy(config, false));
           }
 
           @Override


### PR DESCRIPTION
### Problem

`ResourceUtils.getImageBitmapFromUrl` resolves its future with the pooled bitmap Fresco hands to `BaseBitmapDataSubscriber.onNewResultImpl`. Fresco only guarantees that bitmap is valid inside the callback; once the memory-cache entry is evicted (e.g. `onTrimMemory` while the app is backgrounded), the bitmap is recycled while the notification is still being built, cropped, or parceled. In production this surfaces as `Can't copy a recycled bitmap`, `Can't parcel a recycled bitmap`, and `Canvas: trying to use a recycled bitmap`, and the affected notification is dropped.

### Change

Copy the bitmap inside `onNewResultImpl` so the caller owns its lifetime. Falls back to `ARGB_8888` when `getConfig()` returns null (hardware bitmaps). This is the only `BaseBitmapDataSubscriber` site in the Android core, so it covers `largeIcon`, action icons, and big-picture style.

Cost: one transient bitmap copy per icon fetch.

### Testing

- Verified the copy path compiles and behaves identically for the normal (non-evicted) case.
- The race itself is timing-dependent; it can be forced by triggering `ComponentCallbacks2.onTrimMemory(TRIM_MEMORY_COMPLETE)` (or `adb shell am send-trim-memory <pid> COMPLETE`) between the icon fetch and notification post, which recycles the un-copied bitmap on the old code and is harmless with this change.