### PR TITLE
feat(android): report full-screen intent availability in getNotificationSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Android**: `getNotificationSettings()` now reports `android.fullScreenIntent`, an `AndroidNotificationSetting` describing whether a notification posted with a `fullScreenAction` will actually be shown full screen. On Android 14 / API 34 and above, `USE_FULL_SCREEN_INTENT` is a user-revocable special app access that the Play Store revokes on install for apps outside the calling and alarm categories — and a denial was previously undetectable, because the notification still posts and no error is raised. Below API 34 the value is always `ENABLED`, matching the existing `android.alarm` field.
+
 ### Fixed
 
 - **Android**: fixed notification image handling so Fresco-owned bitmaps are copied before leaving `BaseBitmapDataSubscriber`, preventing later notification build, drawing, or parceling paths from depending on Fresco's bitmap lifetime.
@@ -14,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Tests
 
 - **Android**: added deterministic Robolectric regression coverage for Fresco bitmap ownership, verifying that the source bitmap can be released while the bitmap returned by `ResourceUtils` remains independent and usable.
+- **Android**: added Robolectric coverage for full-screen intent availability across the API 34 boundary, including the fail-open path when the `NotificationManager` is unavailable.
 
 ## [10.5.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Android**: `getNotificationSettings()` now reports `android.fullScreenIntent`, an `AndroidNotificationSetting` describing whether a notification posted with a `fullScreenAction` will actually be shown full screen. On Android 14 / API 34 and above, `USE_FULL_SCREEN_INTENT` is a user-revocable special app access that the Play Store revokes on install for apps outside the calling and alarm categories — and a denial was previously undetectable, because the notification still posts and no error is raised. Below API 34 the value is always `ENABLED`, matching the existing `android.alarm` field.
+- **Android**: `getNotificationSettings().android.fullScreenIntent` now reports whether the app currently has the Android access required to use full-screen intents. API < 29 reports `ENABLED`, API 29–33 reflects `USE_FULL_SCREEN_INTENT`, and API 34+ reflects Android's full-screen intent special app access. `ENABLED` does not guarantee that a particular notification will be presented full-screen.
 
 ### Fixed
 
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Android**: added deterministic regression coverage for `MessagingStyle` `Person` timeouts and icon failures, verifying an icon-less fallback that preserves the remaining `Person` fields while unexpected person-construction failures continue to propagate.
 
 - **Android**: added deterministic Robolectric regression coverage for Fresco bitmap ownership, verifying that the source bitmap can be released while the bitmap returned by `ResourceUtils` remains independent and usable.
-- **Android**: added Robolectric coverage for full-screen intent availability across the API 34 boundary, including the fail-open path when the `NotificationManager` is unavailable.
+- **Android**: added Robolectric coverage for full-screen intent access before API 29, permission grant and denial on API 29–33, and platform access results on API 34+.
 
 - **Android**: added deterministic Robolectric regression coverage for `ReceiverService` `PendingIntent` identity and a physical-device smoke harness covering a notification surviving a process restart, a second notification posted from the new process, real action-button presses, and real dismiss routing; the device scenarios were validated on a Pixel 9 Pro XL running Android 17/API 37.
 

--- a/packages/react-native/__tests__/NotifeeApiModule.test.ts
+++ b/packages/react-native/__tests__/NotifeeApiModule.test.ts
@@ -298,6 +298,7 @@ describe('Notifee Api Module', () => {
           authorizationStatus: AuthorizationStatus.AUTHORIZED,
           android: {
             alarm: AndroidNotificationSetting.DISABLED,
+            fullScreenIntent: AndroidNotificationSetting.ENABLED,
           },
         });
         const settings = await apiModule.getNotificationSettings();
@@ -305,6 +306,7 @@ describe('Notifee Api Module', () => {
           authorizationStatus: AuthorizationStatus.AUTHORIZED,
           android: {
             alarm: 0,
+            fullScreenIntent: 1,
           },
           ios: {
             alert: 1,
@@ -320,6 +322,23 @@ describe('Notifee Api Module', () => {
             authorizationStatus: AuthorizationStatus.AUTHORIZED,
           },
           web: {},
+        });
+      });
+
+      test('passes a denied fullScreenIntent through from the native module', async () => {
+        mockNotifeeNativeModule.getNotificationSettings.mockResolvedValue({
+          authorizationStatus: AuthorizationStatus.AUTHORIZED,
+          android: {
+            alarm: AndroidNotificationSetting.ENABLED,
+            fullScreenIntent: AndroidNotificationSetting.DISABLED,
+          },
+        });
+
+        const settings = await apiModule.getNotificationSettings();
+
+        expect(settings.android).toEqual({
+          alarm: AndroidNotificationSetting.ENABLED,
+          fullScreenIntent: AndroidNotificationSetting.DISABLED,
         });
       });
     });
@@ -352,6 +371,7 @@ describe('Notifee Api Module', () => {
           authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
           android: {
             alarm: AndroidNotificationSetting.ENABLED,
+            fullScreenIntent: AndroidNotificationSetting.ENABLED,
           },
           ios: {
             alert: 1,

--- a/packages/react-native/__tests__/NotifeeApiModule.test.ts
+++ b/packages/react-native/__tests__/NotifeeApiModule.test.ts
@@ -287,6 +287,54 @@ describe('Notifee Api Module', () => {
     });
   });
 
+  describe('requestPermission', () => {
+    test('passes Android full-screen intent access through from the native module', async () => {
+      setPlatform('android');
+      mockNotifeeNativeModule.requestPermission.mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+        android: {
+          alarm: AndroidNotificationSetting.ENABLED,
+          fullScreenIntent: AndroidNotificationSetting.DISABLED,
+        },
+      });
+
+      const settings = await apiModule.requestPermission();
+
+      expect(settings.android).toEqual({
+        alarm: AndroidNotificationSetting.ENABLED,
+        fullScreenIntent: AndroidNotificationSetting.DISABLED,
+      });
+    });
+
+    test('includes Android full-screen intent defaults on iOS', async () => {
+      setPlatform('ios');
+      mockNotifeeNativeModule.requestPermission.mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+        ios: {},
+      });
+
+      const settings = await apiModule.requestPermission();
+
+      expect(settings.android).toEqual({
+        alarm: AndroidNotificationSetting.ENABLED,
+        fullScreenIntent: AndroidNotificationSetting.ENABLED,
+      });
+      expect(mockNotifeeNativeModule.requestPermission).toBeCalledTimes(1);
+    });
+
+    test('includes Android full-screen intent defaults on web', async () => {
+      setPlatform('web');
+
+      const settings = await apiModule.requestPermission();
+
+      expect(settings.android).toEqual({
+        alarm: AndroidNotificationSetting.ENABLED,
+        fullScreenIntent: AndroidNotificationSetting.ENABLED,
+      });
+      expect(mockNotifeeNativeModule.requestPermission).not.toBeCalled();
+    });
+  });
+
   describe('getNotificationSettings', () => {
     describe('on Android', () => {
       beforeEach(() => {
@@ -345,10 +393,10 @@ describe('Notifee Api Module', () => {
 
     describe('on iOS', () => {
       beforeEach(() => {
-        setPlatform('iOS');
+        setPlatform('ios');
       });
 
-      test('return web settings with AndroidNotificationSettings set to default values', async () => {
+      test('returns iOS settings with AndroidNotificationSettings set to default values', async () => {
         mockNotifeeNativeModule.getNotificationSettings.mockResolvedValue({
           authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
           ios: {
@@ -388,6 +436,23 @@ describe('Notifee Api Module', () => {
           },
           web: {},
         });
+        expect(mockNotifeeNativeModule.getNotificationSettings).toBeCalledTimes(1);
+      });
+    });
+
+    describe('on web', () => {
+      beforeEach(() => {
+        setPlatform('web');
+      });
+
+      test('returns AndroidNotificationSettings default values', async () => {
+        const settings = await apiModule.getNotificationSettings();
+
+        expect(settings.android).toEqual({
+          alarm: AndroidNotificationSetting.ENABLED,
+          fullScreenIntent: AndroidNotificationSetting.ENABLED,
+        });
+        expect(mockNotifeeNativeModule.getNotificationSettings).not.toBeCalled();
       });
     });
   });

--- a/packages/react-native/android/src/main/java/app/notifee/core/Notifee.java
+++ b/packages/react-native/android/src/main/java/app/notifee/core/Notifee.java
@@ -36,6 +36,7 @@ import app.notifee.core.model.ChannelGroupModel;
 import app.notifee.core.model.ChannelModel;
 import app.notifee.core.model.NotificationModel;
 import app.notifee.core.utility.AlarmUtils;
+import app.notifee.core.utility.FullScreenIntentUtils;
 import app.notifee.core.utility.PowerManagerUtils;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -506,6 +507,14 @@ public class Notifee {
       androidSettingsBundle.putInt("alarm", 1);
     } else {
       androidSettingsBundle.putInt("alarm", 0);
+    }
+
+    boolean canUseFullScreenIntent = FullScreenIntentUtils.canUseFullScreenIntent();
+
+    if (canUseFullScreenIntent) {
+      androidSettingsBundle.putInt("fullScreenIntent", 1);
+    } else {
+      androidSettingsBundle.putInt("fullScreenIntent", 0);
     }
 
     notificationSettingsBundle.putBundle("android", androidSettingsBundle);

--- a/packages/react-native/android/src/main/java/app/notifee/core/utility/FullScreenIntentUtils.java
+++ b/packages/react-native/android/src/main/java/app/notifee/core/utility/FullScreenIntentUtils.java
@@ -19,53 +19,35 @@ package app.notifee.core.utility;
 
 import static app.notifee.core.ContextHolder.getApplicationContext;
 
-import android.app.NotificationManager;
 import android.content.Context;
-import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.app.NotificationManagerCompat;
 
 public class FullScreenIntentUtils {
 
-  @Nullable
-  private static NotificationManager getNotificationManager() {
-    Context context = getApplicationContext();
-    if (context == null) {
-      return null;
-    }
-    return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-  }
-
   /**
-   * Whether a notification posted with a full screen action will actually be shown full screen.
+   * Whether the app currently has the Android access required to use full-screen intents.
    *
-   * <p>On Android 14 / API 34 and above, {@code USE_FULL_SCREEN_INTENT} is a user-revocable special
-   * app access rather than a normal install-time permission: the Play Store revokes it on install
-   * for apps outside the calling and alarm categories, and the user can toggle it at any time. When
-   * it is denied the notification still posts normally and nothing throws — only the full screen
-   * presentation is dropped — so this is the sole reliable way to detect it.
+   * <p>API levels below 29 do not use the full-screen intent permission model. API levels 29
+   * through 33 require {@code USE_FULL_SCREEN_INTENT}. API level 34 and above use Android's
+   * full-screen intent special app access.
    *
-   * <p>Below API 34 the manifest permission is granted at install and always honoured.
-   *
-   * @return true when a full screen intent will be honoured, false when the user or the system has
-   *     denied it.
+   * @return true when the required access is currently available. This does not guarantee that a
+   *     particular notification will be presented full-screen.
    */
   public static boolean canUseFullScreenIntent() {
-    return canUseFullScreenIntent(getNotificationManager());
+    return canUseFullScreenIntent(getApplicationContext());
   }
 
   @VisibleForTesting
-  static boolean canUseFullScreenIntent(@Nullable NotificationManager notificationManager) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+  static boolean canUseFullScreenIntent(@Nullable Context context) {
+    // The application context is expected to exist on the public path. Preserve the existing
+    // defensive fail-open behavior for an internal state that cannot prove access is denied.
+    if (context == null) {
       return true;
     }
 
-    // Fail open: an absent NotificationManager tells us nothing, and reporting a denial we
-    // cannot prove would have apps nag the user about a setting that may well be granted.
-    if (notificationManager == null) {
-      return true;
-    }
-
-    return notificationManager.canUseFullScreenIntent();
+    return NotificationManagerCompat.from(context).canUseFullScreenIntent();
   }
 }

--- a/packages/react-native/android/src/main/java/app/notifee/core/utility/FullScreenIntentUtils.java
+++ b/packages/react-native/android/src/main/java/app/notifee/core/utility/FullScreenIntentUtils.java
@@ -1,0 +1,71 @@
+package app.notifee.core.utility;
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import static app.notifee.core.ContextHolder.getApplicationContext;
+
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+public class FullScreenIntentUtils {
+
+  @Nullable
+  private static NotificationManager getNotificationManager() {
+    Context context = getApplicationContext();
+    if (context == null) {
+      return null;
+    }
+    return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+  }
+
+  /**
+   * Whether a notification posted with a full screen action will actually be shown full screen.
+   *
+   * <p>On Android 14 / API 34 and above, {@code USE_FULL_SCREEN_INTENT} is a user-revocable special
+   * app access rather than a normal install-time permission: the Play Store revokes it on install
+   * for apps outside the calling and alarm categories, and the user can toggle it at any time. When
+   * it is denied the notification still posts normally and nothing throws — only the full screen
+   * presentation is dropped — so this is the sole reliable way to detect it.
+   *
+   * <p>Below API 34 the manifest permission is granted at install and always honoured.
+   *
+   * @return true when a full screen intent will be honoured, false when the user or the system has
+   *     denied it.
+   */
+  public static boolean canUseFullScreenIntent() {
+    return canUseFullScreenIntent(getNotificationManager());
+  }
+
+  @VisibleForTesting
+  static boolean canUseFullScreenIntent(@Nullable NotificationManager notificationManager) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      return true;
+    }
+
+    // Fail open: an absent NotificationManager tells us nothing, and reporting a denial we
+    // cannot prove would have apps nag the user about a setting that may well be granted.
+    if (notificationManager == null) {
+      return true;
+    }
+
+    return notificationManager.canUseFullScreenIntent();
+  }
+}

--- a/packages/react-native/android/src/test/java/app/notifee/core/utility/FullScreenIntentUtilsTest.java
+++ b/packages/react-native/android/src/test/java/app/notifee/core/utility/FullScreenIntentUtilsTest.java
@@ -1,0 +1,86 @@
+package app.notifee.core.utility;
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.app.NotificationManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Unit coverage for {@link FullScreenIntentUtils#canUseFullScreenIntent(NotificationManager)},
+ * which backs the {@code android.fullScreenIntent} field of {@code getNotificationSettings()}.
+ *
+ * <p>Android 14 / API 34 turned {@code USE_FULL_SCREEN_INTENT} into a user-revocable special app
+ * access. The interesting behavior is therefore the API level boundary, so each case pins the SDK
+ * with {@link Config} and injects the {@link NotificationManager} rather than relying on a shadow —
+ * Robolectric does not implement {@code canUseFullScreenIntent()}.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class FullScreenIntentUtilsTest {
+
+  @Test
+  @Config(sdk = 33)
+  public void returnsTrueBelowApi34WithoutConsultingNotificationManager() {
+    // Deliberately unstubbed: an unstubbed boolean mock answers false, so a true result proves
+    // the version guard short-circuited. The method is not referenced by name here because it
+    // does not exist on the API 33 android-all jar Robolectric loads for this case.
+    NotificationManager notificationManager = mock(NotificationManager.class);
+
+    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
+  }
+
+  @Test
+  @Config(sdk = 34)
+  public void returnsTrueOnApi34WhenGranted() {
+    NotificationManager notificationManager = mock(NotificationManager.class);
+    when(notificationManager.canUseFullScreenIntent()).thenReturn(true);
+
+    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
+  }
+
+  @Test
+  @Config(sdk = 34)
+  public void returnsFalseOnApi34WhenDenied() {
+    NotificationManager notificationManager = mock(NotificationManager.class);
+    when(notificationManager.canUseFullScreenIntent()).thenReturn(false);
+
+    assertFalse(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
+  }
+
+  @Test
+  @Config(sdk = 35)
+  public void keepsConsultingNotificationManagerAboveApi34() {
+    // Guards against the version check regressing into an equality test against 34.
+    NotificationManager notificationManager = mock(NotificationManager.class);
+    when(notificationManager.canUseFullScreenIntent()).thenReturn(false);
+
+    assertFalse(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
+  }
+
+  @Test
+  @Config(sdk = 34)
+  public void failsOpenWhenNotificationManagerIsUnavailable() {
+    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(null));
+  }
+}

--- a/packages/react-native/android/src/test/java/app/notifee/core/utility/FullScreenIntentUtilsTest.java
+++ b/packages/react-native/android/src/test/java/app/notifee/core/utility/FullScreenIntentUtilsTest.java
@@ -21,66 +21,63 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import android.Manifest;
 import android.app.NotificationManager;
+import android.content.Context;
+import android.content.pm.PackageManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /**
- * Unit coverage for {@link FullScreenIntentUtils#canUseFullScreenIntent(NotificationManager)},
- * which backs the {@code android.fullScreenIntent} field of {@code getNotificationSettings()}.
- *
- * <p>Android 14 / API 34 turned {@code USE_FULL_SCREEN_INTENT} into a user-revocable special app
- * access. The interesting behavior is therefore the API level boundary, so each case pins the SDK
- * with {@link Config} and injects the {@link NotificationManager} rather than relying on a shadow —
- * Robolectric does not implement {@code canUseFullScreenIntent()}.
+ * Unit coverage for the cross-version access contract backing the {@code android.fullScreenIntent}
+ * field of {@code getNotificationSettings()}.
  */
 @RunWith(RobolectricTestRunner.class)
 public class FullScreenIntentUtilsTest {
 
   @Test
+  @Config(sdk = 28)
+  public void returnsTrueBelowApi29WithoutPermission() {
+    Context context = mock(Context.class);
+    when(context.checkSelfPermission(Manifest.permission.USE_FULL_SCREEN_INTENT))
+        .thenReturn(PackageManager.PERMISSION_DENIED);
+
+    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(context));
+  }
+
+  @Test
   @Config(sdk = 33)
-  public void returnsTrueBelowApi34WithoutConsultingNotificationManager() {
-    // Deliberately unstubbed: an unstubbed boolean mock answers false, so a true result proves
-    // the version guard short-circuited. The method is not referenced by name here because it
-    // does not exist on the API 33 android-all jar Robolectric loads for this case.
-    NotificationManager notificationManager = mock(NotificationManager.class);
+  public void reflectsPermissionAndRereadsItFromApi29Through33() {
+    Context context = mock(Context.class);
+    when(context.checkSelfPermission(Manifest.permission.USE_FULL_SCREEN_INTENT))
+        .thenReturn(PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_DENIED);
 
-    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
+    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(context));
+    assertFalse(FullScreenIntentUtils.canUseFullScreenIntent(context));
   }
 
   @Test
   @Config(sdk = 34)
-  public void returnsTrueOnApi34WhenGranted() {
+  public void reflectsAccessChangesOnApi34() {
+    Context context = mock(Context.class);
     NotificationManager notificationManager = mock(NotificationManager.class);
-    when(notificationManager.canUseFullScreenIntent()).thenReturn(true);
+    when(context.getSystemService(Context.NOTIFICATION_SERVICE)).thenReturn(notificationManager);
+    when(notificationManager.canUseFullScreenIntent()).thenReturn(true, false);
 
-    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
-  }
-
-  @Test
-  @Config(sdk = 34)
-  public void returnsFalseOnApi34WhenDenied() {
-    NotificationManager notificationManager = mock(NotificationManager.class);
-    when(notificationManager.canUseFullScreenIntent()).thenReturn(false);
-
-    assertFalse(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
+    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(context));
+    assertFalse(FullScreenIntentUtils.canUseFullScreenIntent(context));
   }
 
   @Test
   @Config(sdk = 35)
   public void keepsConsultingNotificationManagerAboveApi34() {
-    // Guards against the version check regressing into an equality test against 34.
+    Context context = mock(Context.class);
     NotificationManager notificationManager = mock(NotificationManager.class);
-    when(notificationManager.canUseFullScreenIntent()).thenReturn(false);
+    when(context.getSystemService(Context.NOTIFICATION_SERVICE)).thenReturn(notificationManager);
+    when(notificationManager.canUseFullScreenIntent()).thenReturn(true);
 
-    assertFalse(FullScreenIntentUtils.canUseFullScreenIntent(notificationManager));
-  }
-
-  @Test
-  @Config(sdk = 34)
-  public void failsOpenWhenNotificationManagerIsUnavailable() {
-    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(null));
+    assertTrue(FullScreenIntentUtils.canUseFullScreenIntent(context));
   }
 }

--- a/packages/react-native/jest-mock.js
+++ b/packages/react-native/jest-mock.js
@@ -83,6 +83,7 @@ export const testNotificationSettings = {
   authorizationStatus: Notification.AuthorizationStatus.AUTHORIZED,
   android: {
     alarm: NotificationAndroid.AndroidNotificationSetting.ENABLED,
+    fullScreenIntent: NotificationAndroid.AndroidNotificationSetting.ENABLED,
   },
   ios: {
     alert: true,

--- a/packages/react-native/src/NotifeeApiModule.ts
+++ b/packages/react-native/src/NotifeeApiModule.ts
@@ -602,6 +602,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
             ios,
             android: {
               alarm: AndroidNotificationSetting.ENABLED,
+              fullScreenIntent: AndroidNotificationSetting.ENABLED,
             },
             web: {},
           };
@@ -614,6 +615,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
       authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
       android: {
         alarm: AndroidNotificationSetting.ENABLED,
+        fullScreenIntent: AndroidNotificationSetting.ENABLED,
       },
       ios: {
         alert: 1,
@@ -725,6 +727,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
             ios,
             android: {
               alarm: AndroidNotificationSetting.ENABLED,
+              fullScreenIntent: AndroidNotificationSetting.ENABLED,
             },
             web: {},
           };
@@ -737,6 +740,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
       authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
       android: {
         alarm: AndroidNotificationSetting.ENABLED,
+        fullScreenIntent: AndroidNotificationSetting.ENABLED,
       },
       ios: {
         alert: 1,

--- a/packages/react-native/src/types/NotificationAndroid.ts
+++ b/packages/react-native/src/types/NotificationAndroid.ts
@@ -501,6 +501,21 @@ export interface AndroidNotificationSettings {
    * View the [Trigger](/react-native/android/triggers#android-12-limitations) documentation for more information.
    */
   alarm: AndroidNotificationSetting;
+
+  /**
+   * Enum describing if a notification with a `fullScreenAction` will actually be shown full screen.
+   *
+   * For Android < 14 / API < 34, this will default to enabled.
+   *
+   * On Android 14 / API 34 and above, `USE_FULL_SCREEN_INTENT` is a user-revocable special app
+   * access rather than a normal install-time permission. It is revoked on install for apps outside
+   * the calling and alarm categories, and the user can toggle it at any time. While it is disabled
+   * the notification still posts and no error is raised — only the full screen presentation is
+   * dropped, so this setting is the only way to detect it.
+   *
+   * Send the user to `Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT` to have it granted.
+   */
+  fullScreenIntent: AndroidNotificationSetting;
 }
 
 /**

--- a/packages/react-native/src/types/NotificationAndroid.ts
+++ b/packages/react-native/src/types/NotificationAndroid.ts
@@ -503,19 +503,15 @@ export interface AndroidNotificationSettings {
   alarm: AndroidNotificationSetting;
 
   /**
-   * Enum describing if a notification with a `fullScreenAction` will actually be shown full screen.
+   * Enum describing whether the app currently has the Android access required to use full-screen intents.
    *
-   * For Android < 14 / API < 34, this will default to enabled.
+   * API < 29 reports `ENABLED` because the later permission model does not apply. API 29–33 reflects
+   * `USE_FULL_SCREEN_INTENT`. API 34+ reflects Android's full-screen intent special app access,
+   * which may be restricted or revoked by the system, installer, or user.
    *
-   * On Android 14 / API 34 and above, `USE_FULL_SCREEN_INTENT` is a user-revocable special app
-   * access rather than a normal install-time permission. It is revoked on install for apps outside
-   * the calling and alarm categories, and the user can toggle it at any time. While it is disabled
-   * the notification still posts and no error is raised — only the full screen presentation is
-   * dropped, so this setting is the only way to detect it.
-   *
-   * Send the user to `Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT` to have it granted.
+   * `ENABLED` does not guarantee that a particular notification will be presented full-screen.
    */
-  fullScreenIntent: AndroidNotificationSetting;
+  fullScreenIntent?: AndroidNotificationSetting;
 }
 
 /**


### PR DESCRIPTION
Closes #64.

## What

Adds `android.fullScreenIntent` to `getNotificationSettings()`, an `AndroidNotificationSetting` reporting whether a notification posted with a `fullScreenAction` will actually be shown full screen.

## Why

Android 14 / API 34 turned `USE_FULL_SCREEN_INTENT` into a user-revocable special app access: the Play Store revokes it on install for apps outside the calling and alarm categories, apps installed before the device upgraded keep it, and the user can toggle it at any time under Settings → Apps → Special app access.

**A denial is completely silent.** The notification still posts, the promise resolves, nothing throws — only the full-screen presentation is dropped. None of the signals available to JS help:

- `Build.VERSION.SDK_INT` — the state is per-app and per-user, not per-OS-version.
- The manifest permission — `dumpsys package` still reports `granted=true` while the app-op denies it.
- `getNotificationSettings()` — reports `authorizationStatus` and `android.alarm`, both of which stay green.

The only reliable signal is `NotificationManager.canUseFullScreenIntent()`, which has no binding here and **cannot be added from JS**. A calling app is left ringing without ever taking the lock screen, unable to explain why or offer the one-tap fix.

## Shape

Deliberately modelled on the existing `alarm` ← `AlarmManager.canScheduleExactAlarms()` field — one boolean special-access check, one `AndroidNotificationSetting`, **no new method on the public API surface**:

| Condition | Value |
| --- | --- |
| API &lt; 34 | `ENABLED` — granted at install, always honoured |
| API ≥ 34, `canUseFullScreenIntent()` true | `ENABLED` |
| API ≥ 34, `canUseFullScreenIntent()` false | `DISABLED` |
| iOS / web | `ENABLED` — the same fallback `alarm` already uses |

`FullScreenIntentUtils.canUseFullScreenIntent()` **fails open** when the `NotificationManager` is unavailable: a state we cannot prove is not one apps should nag the user about.

### Scope

**Detection only.** I left out an `openFullScreenIntentSettings()` companion to `openAlarmPermissionSettings()` on purpose — launching `Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT` is already possible from JS with any intent launcher, so it isn't a gap. Detection is the part JS cannot do. Happy to add it in a follow-up if you'd like the pair symmetric.

### Why this touches the core

`packages/react-native/android/.../Notifee.java` is the only place the value can come from — it's behind a native `NotificationManager` call, so the bridge layer can't reach it. Per `CONTRIBUTING.md` ("Modifications to the core are therefore fully allowed when the bridge layer isn't the right place"), flagging explicitly since the issue template still says the core isn't modified. The change is 9 lines in `getNotificationSettings`, immediately beside the `alarm` block it mirrors, plus one new utility.

## Changes

| File | |
| --- | --- |
| `utility/FullScreenIntentUtils.java` | **new** — SDK-gated check, mirroring `AlarmUtils.canScheduleExactAlarms()` |
| `Notifee.java` | writes `fullScreenIntent` into the android settings bundle |
| `utility/FullScreenIntentUtilsTest.java` | **new** — 5 Robolectric cases across the API boundary |
| `types/NotificationAndroid.ts` | the new field + JSDoc |
| `NotifeeApiModule.ts` | all four iOS/web fallback construction sites (`requestPermission` ×2, `getNotificationSettings` ×2) |
| `jest-mock.js` | `testNotificationSettings` fixture |
| `__tests__/NotifeeApiModule.test.ts` | updated assertions + a new pass-through case for a denied grant |
| `CHANGELOG.md` | `[Unreleased] → Added` |

## Verification

Run on Windows, Node 22.20.0, JDK 17:

- `yarn tests_rn:test` — **654 passed, 38 suites**, including the new case
- `./gradlew :react-native-notify-kit:testDebugUnitTest` — the new suite reports `tests="5" skipped="0" failures="0" errors="0"`
- `yarn validate:all:ts` — clean
- Prettier — clean on every file touched

One thing to flag so it isn't mistaken for my change: in my Windows environment 14 of the 15 tests in `NotifeeAlarmManagerCurrentBehaviorTest` fail with `IllegalStateException: Illegal connection pointer` (Room/SQLite under Robolectric), which turns the whole Gradle task red. I re-ran that suite on a clean `dev` checkout with no changes applied and got the identical 14/15, so it is environmental and pre-existing rather than anything this PR touches. Every other suite is green.

**On device: not verified for this PR, and I want to be straight about that.** The identical native logic has been shipping in a production Android calling app via `patch-package`, which is where the problem was found and diagnosed (the tell was a missing `fullscreenIntent=` line in `dumpsys notification` while `dumpsys package` still showed the permission granted). But the full grant → revoke → re-read cycle on an API 34 device was not re-run against this branch — the coverage here is the Robolectric matrix pinning both sides of the API boundary. Glad to do a device pass if you'd like one before merging.

One note: I did not regenerate `docs/react-native/reference/` — typedoc output carries source line-number links, so it churns unrelated files. Say the word and I'll run `yarn gen:reference` here instead of leaving it to the release.
